### PR TITLE
Fixing OpenBSD's host checkup

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -490,7 +490,7 @@ get_host() {
         (OpenBSD*)
             product=$(sysctl -n hw.product)
             version=$(sysctl -n hw.version)
-            host="$product $version"
+            host="$(sysctl -n hw.product) $(sysctl -n hw.version)"
         ;;
 
         (*BSD*|Minix)

--- a/pfetch
+++ b/pfetch
@@ -488,7 +488,9 @@ get_host() {
         ;;
 
         (OpenBSD*)
-            host=$(sysctl -n hw.version)
+            product=$(sysctl -n hw.product)
+            version=$(sysctl -n hw.version)
+            host="$product $version"
         ;;
 
         (*BSD*|Minix)

--- a/pfetch
+++ b/pfetch
@@ -488,8 +488,6 @@ get_host() {
         ;;
 
         (OpenBSD*)
-            product=$(sysctl -n hw.product)
-            version=$(sysctl -n hw.version)
             host="$(sysctl -n hw.product) $(sysctl -n hw.version)"
         ;;
 


### PR DESCRIPTION
Fixing host checkup in OpenBSD on VirtualBox it showed only `1.2`: ![pfetch_fix_0](https://github.com/Un1q32/pfetch/assets/156322098/64b39a64-cd62-4d20-8926-2c27af6c3fbb)
, but now it shows `VirtualBox 1.2`: 
![pfetch_fix_1](https://github.com/Un1q32/pfetch/assets/156322098/bb442ac2-40bb-4999-9f7f-7516d410ffa4)

For comparison, this is Alpine Linux's pfetch running on VirtualBox":
![pfetch_fix_2](https://github.com/Un1q32/pfetch/assets/156322098/ec0ffc69-62ec-4453-b1bb-21ac32490d8a)
