### PR TITLE
Fix NetBSD's host checkup.

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -476,16 +476,11 @@ get_host() {
             host="$name $version $model"
         ;;
 
-        (Darwin*|FreeBSD*|DragonFly*)
+        (Darwin*|FreeBSD*|DragonFly*|NetBSD*)
             case $distro in
                 iOS*) host=$(uname -m)           ;;
                 *)    host=$(sysctl -n hw.model) ;;
             esac
-        ;;
-
-        (NetBSD*)
-            host=$(/sbin/sysctl -n machdep.dmi.system-vendor \
-                                   machdep.dmi.system-product)
         ;;
 
         (OpenBSD*)

--- a/pfetch
+++ b/pfetch
@@ -476,11 +476,15 @@ get_host() {
             host="$name $version $model"
         ;;
 
-        (Darwin*|FreeBSD*|DragonFly*|NetBSD*)
+        (Darwin*|FreeBSD*|DragonFly*)
             case $distro in
                 iOS*) host=$(uname -m)           ;;
                 *)    host=$(sysctl -n hw.model) ;;
             esac
+        ;;
+
+        (NetBSD*)
+            host=$(/sbin/sysctl -n hw.model)
         ;;
 
         (OpenBSD*)


### PR DESCRIPTION
When running under a VM (for example FreeBSD's `bhyve` hypervisor) the host information of NetBSD does not represent the `host` in the expected manner

![image](https://github.com/Un1q32/pfetch/assets/189939/124e138b-ee2b-4086-807b-4dbb584b6c41)

As an example, for a FreeBSD VM running under `bhyve` hypervisor shows

![image](https://github.com/Un1q32/pfetch/assets/189939/d12bbef9-8c75-441d-88c1-99aef4da5789)

The PR attempts to fix this by making NetBSD's output to be more consistent by depending on the same `sysctl` property `hw.model` as used by FreeBSD. The result after applying the patch looks as show below

![image](https://github.com/Un1q32/pfetch/assets/189939/d1d76c93-0f7b-4092-96f8-e5a71dee9e4b)
