### PR TITLE
Added chocolatey for WSL

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -778,6 +778,7 @@ get_pkgs() {
             has anise      && count_pkg anise 0 anise s --installed
             has nix-store  && count_pkg nix 0 nix_pkg_count
             has winget.exe && count_pkg winget 2 winget.exe list
+            has choco.exe  && count_pkg chocolatey 2 choco.exe list
             has pm         && _p="$(pm list packages)" &&
                 count_pkg pm 0 printf '%s\n' "$_p"
 


### PR DESCRIPTION
```
$ PF_PACKAGE_MANAGERS=on ./pfetch
  _____     stefan@Stefan-PC
 /  __ \    os     Debian GNU/Linux 12 (bookworm) on Windows [WSL2]
|  /    |   host   x86_64
|  \___-    kernel 4.4.0-19041-Microsoft
-_          uptime 1h 38m
  --_       pkgs   2149 (dpkg), 229 (winget), 3 (chocolatey)
            memory 9569M / 16335M
$ choco.exe list
Chocolatey v2.4.3
chocolatey 2.4.3
less 668.0.0
vim 9.1.1265
3 packages installed.